### PR TITLE
FIX: Spaces preserverd

### DIFF
--- a/js/src/sass-to-js.js
+++ b/js/src/sass-to-js.js
@@ -75,7 +75,7 @@
      * @returns {String} Normalized for JSON.stringify CSS value string
      */
     function _normalizeCssValue(string) {
-        string = string.replace(/^['"]+|\s+|\\|(;\s?})+|['"]$/g, '');
+        string = string.replace(/^['"]+|\\|(;\s?})+|['"]$/g, '');
 
         return string;
     }


### PR DESCRIPTION
CSS-Properties with multiple, space-separated values were treated incorrectly.
eg "background: repeating-linear-gradient(red, yellow 10%, green 20%);"
Previous result of _normalizeCssValue: "repeating-linear-gradient(red,yellow10%,green20%)"
Fixed result of _normalizeCssValue: "repeating-linear-gradient(red, yellow 10%, green 20%)"